### PR TITLE
Bitrise PR build fix attempt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ apply plugin: "androidx.navigation.safeargs.kotlin"
 
 androidGitVersion {
     format "%tag%%-branch%%-count%%-dirty%"
+    baseCode 1
 }
 
 android {


### PR DESCRIPTION
Set a base code to try to avoid a code of 0

The build fails with a 0 version code during the PR build process because something about the plugin isn't working as expected (likely related to the way that Bitrise pulls the code for a PR). I'm hoping that doing this forces at least a valid build code so that it can still build.