### PR TITLE
Dark Mode switcher + Preferences Screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 
     def nav_version = "2.1.0-alpha05"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0-alpha01"
 
@@ -113,6 +113,8 @@ dependencies {
 
     androidTestImplementation 'com.jakewharton.espresso:okhttp3-idling-resource:1.0.0'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.12.0'
+
+    implementation 'androidx.preference:preference-ktx:1.1.0-beta01'
 }
 
 detekt {

--- a/app/src/main/java/dev/bryanlindsey/trivia/MainActivity.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/MainActivity.kt
@@ -1,5 +1,21 @@
 package dev.bryanlindsey.trivia
 
+import android.view.Menu
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.findNavController
+import androidx.navigation.ui.onNavDestinationSelected
 
-class MainActivity : AppCompatActivity(R.layout.activity_main)
+class MainActivity : AppCompatActivity(R.layout.activity_main) {
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        val inflater = menuInflater
+        inflater.inflate(R.menu.main_settings, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        val navController = findNavController(R.id.nav_host_fragment)
+        return item.onNavDestinationSelected(navController) || super.onOptionsItemSelected(item)
+    }
+}

--- a/app/src/main/java/dev/bryanlindsey/trivia/TriviaApplication.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/TriviaApplication.kt
@@ -2,7 +2,9 @@ package dev.bryanlindsey.trivia
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
+import androidx.preference.PreferenceManager
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import dev.bryanlindsey.trivia.di.firebaseModule
@@ -12,6 +14,8 @@ import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
+const val DEFAULT_DARK_MODE_SETTING = true
+
 class TriviaApplication : Application() {
 
     private val firebaseRemoteConfig: FirebaseRemoteConfig by inject()
@@ -19,7 +23,10 @@ class TriviaApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        AppCompatDelegate.setDefaultNightMode(MODE_NIGHT_YES)
+        val preferences = PreferenceManager.getDefaultSharedPreferences(this)
+        val isDarkModeEnabled = preferences.getBoolean("theme", DEFAULT_DARK_MODE_SETTING)
+        val nightModeFlag = if (isDarkModeEnabled) MODE_NIGHT_YES else MODE_NIGHT_NO
+        AppCompatDelegate.setDefaultNightMode(nightModeFlag)
 
         startKoin {
             androidContext(this@TriviaApplication)

--- a/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
@@ -1,6 +1,8 @@
 package dev.bryanlindsey.trivia.settings
 
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
 
@@ -15,6 +17,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
             title = "Dark mode"
             summary = "Enable dark mode"
         }
+
+        themePreference.onPreferenceChangeListener =
+            Preference.OnPreferenceChangeListener { _, newValue ->
+                val nightModeFlag = if (newValue == true) AppCompatDelegate.MODE_NIGHT_YES else AppCompatDelegate.MODE_NIGHT_NO
+                AppCompatDelegate.setDefaultNightMode(nightModeFlag)
+                true
+            }
 
         screen.addPreference(themePreference)
         preferenceScreen = screen

--- a/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
+import dev.bryanlindsey.trivia.DEFAULT_DARK_MODE_SETTING
 
 class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -16,6 +17,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             key = "theme"
             title = "Dark mode"
             summary = "Enable dark mode"
+            setDefaultValue(DEFAULT_DARK_MODE_SETTING)
         }
 
         themePreference.onPreferenceChangeListener =

--- a/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
@@ -2,6 +2,8 @@ package dev.bryanlindsey.trivia.settings
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
+import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
@@ -22,7 +24,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         themePreference.onPreferenceChangeListener =
             Preference.OnPreferenceChangeListener { _, newValue ->
-                val nightModeFlag = if (newValue == true) AppCompatDelegate.MODE_NIGHT_YES else AppCompatDelegate.MODE_NIGHT_NO
+                val nightModeFlag = if (newValue == true) MODE_NIGHT_YES else MODE_NIGHT_NO
                 AppCompatDelegate.setDefaultNightMode(nightModeFlag)
                 true
             }

--- a/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
@@ -1,0 +1,22 @@
+package dev.bryanlindsey.trivia.settings
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
+
+class SettingsFragment : PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+
+        val context = preferenceManager.context
+        val screen = preferenceManager.createPreferenceScreen(context)
+
+        val themePreference = SwitchPreferenceCompat(context).apply {
+            key = "theme"
+            title = "Dark mode"
+            summary = "Enable dark mode"
+        }
+
+        screen.addPreference(themePreference)
+        preferenceScreen = screen
+    }
+}

--- a/app/src/main/java/dev/bryanlindsey/trivia/triviaquestiondisplay/TriviaQuestionDisplayFragment.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/triviaquestiondisplay/TriviaQuestionDisplayFragment.kt
@@ -30,8 +30,6 @@ class TriviaQuestionDisplayFragment : Fragment(R.layout.trivia_questions_fragmen
                 render(it)
             }
         )
-
-        triviaQuestionDisplayViewModel.getMoreTriviaQuestions()
     }
 
     private fun render(data: TriviaApiResponse) {

--- a/app/src/main/java/dev/bryanlindsey/trivia/triviaquestiondisplay/TriviaQuestionDisplayViewModel.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/triviaquestiondisplay/TriviaQuestionDisplayViewModel.kt
@@ -16,6 +16,10 @@ class TriviaQuestionDisplayViewModel(private val triviaService: TriviaService) :
 
     var triviaQuestionsLiveData: LiveData<TriviaApiResponse> = _triviaQuestionsLiveData
 
+    init {
+        getMoreTriviaQuestions()
+    }
+
     fun getMoreTriviaQuestions() =
         viewModelScope.launch {
             val response = triviaService.getTriviaQuestions(DEFAULT_QUESTION_COUNT)

--- a/app/src/main/res/menu/main_settings.xml
+++ b/app/src/main/res/menu/main_settings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/settingsFragment"
+        android:title="Settings"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/menu/main_settings.xml
+++ b/app/src/main/res/menu/main_settings.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/settingsFragment"
+        android:menuCategory="secondary"
         android:title="Settings"
         app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -45,4 +45,8 @@
             android:name="pointsPossible"
             app:argType="integer" />
     </fragment>
+    <fragment
+        android:id="@+id/settingsFragment"
+        android:name="dev.bryanlindsey.trivia.settings.SettingsFragment"
+        android:label="SettingsFragment" />
 </navigation>


### PR DESCRIPTION
This was primarily meant to test out using a preferences screen (inspired by https://joebirch.co/2019/06/19/exploring-android-jetpack-preferences/). 

It also gave me a chance to implement a dark mode switcher. This will also be useful for helping me explore Dark mode design further.