### PR TITLE
JaCoCo CI reports

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -129,7 +129,7 @@ detekt {
 /**
  * Adapted from https://medium.com/@rafael_toledo/unified-code-coverage-for-android-revisited-44789c9b722f
  */
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+task jacocoTestReport(type: JacocoReport) {
     group = "Reporting"
     description = "Generate Jacoco coverage reports for Debug build"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -163,7 +163,7 @@ task jacocoTestReport(type: JacocoReport) {
             android.sourceSets.main.java.srcDirs,
             "$project.projectDir/src/main/java"
     ])
-    executionData = fileTree(dir: project.buildDir, includes: ['jacoco/testDebugUnitTest.exec'])
+    executionData = fileTree(dir: project.buildDir, includes: ['jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*.ec'])
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,4 +166,20 @@ task jacocoTestReport(type: JacocoReport) {
     executionData = fileTree(dir: project.buildDir, includes: ['jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*.ec'])
 }
 
+configurations { codacy }
+dependencies {
+    codacy 'com.github.codacy:codacy-coverage-reporter:-SNAPSHOT'
+}
+task sendCoverageToCodacy(type: JavaExec, dependsOn: jacocoTestReport) {
+    main = "com.codacy.CodacyCoverageReporter"
+    classpath = configurations.codacy
+    args = [
+            "report",
+            "-l",
+            "Kotlin",
+            "-r",
+            "${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+    ]
+}
+
 apply plugin: 'com.google.gms.google-services'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,9 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+
+        maven { url "https://jitpack.io" }
+        maven { url "http://dl.bintray.com/typesafe/maven-releases" }
     }
 }
 


### PR DESCRIPTION
Generate JaCoCo reports as part of the CI process, and push the results up to code quality tools. Currently, I have Codacy set up.