### PR TITLE
Setting for Number of questions

### DIFF
--- a/app/src/main/java/dev/bryanlindsey/trivia/TriviaApplication.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/TriviaApplication.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
 import androidx.preference.PreferenceManager
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import dev.bryanlindsey.trivia.di.androidModule
 import dev.bryanlindsey.trivia.di.firebaseModule
 import dev.bryanlindsey.trivia.di.viewModelModule
 import dev.bryanlindsey.trivia.remote.networkModule
@@ -32,6 +33,7 @@ class TriviaApplication : Application() {
             androidContext(this@TriviaApplication)
             modules(
                 listOf(
+                    androidModule,
                     networkModule,
                     viewModelModule,
                     firebaseModule

--- a/app/src/main/java/dev/bryanlindsey/trivia/TriviaApplication.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/TriviaApplication.kt
@@ -1,10 +1,10 @@
 package dev.bryanlindsey.trivia
 
 import android.app.Application
+import android.content.SharedPreferences
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
-import androidx.preference.PreferenceManager
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import dev.bryanlindsey.trivia.di.androidModule
@@ -19,16 +19,23 @@ const val DEFAULT_DARK_MODE_SETTING = true
 
 class TriviaApplication : Application() {
 
+    private val preferences: SharedPreferences by inject()
+
     private val firebaseRemoteConfig: FirebaseRemoteConfig by inject()
 
     override fun onCreate() {
         super.onCreate()
 
-        val preferences = PreferenceManager.getDefaultSharedPreferences(this)
+        setUpDi()
+
         val isDarkModeEnabled = preferences.getBoolean("theme", DEFAULT_DARK_MODE_SETTING)
         val nightModeFlag = if (isDarkModeEnabled) MODE_NIGHT_YES else MODE_NIGHT_NO
         AppCompatDelegate.setDefaultNightMode(nightModeFlag)
 
+        setUpFirebase()
+    }
+
+    private fun setUpDi() {
         startKoin {
             androidContext(this@TriviaApplication)
             modules(
@@ -40,8 +47,6 @@ class TriviaApplication : Application() {
                 )
             )
         }
-
-        setUpFirebase()
     }
 
     private fun setUpFirebase() {

--- a/app/src/main/java/dev/bryanlindsey/trivia/di/AndroidModule.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/di/AndroidModule.kt
@@ -1,0 +1,9 @@
+package dev.bryanlindsey.trivia.di
+
+import androidx.preference.PreferenceManager
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.module
+
+val androidModule = module {
+    single { PreferenceManager.getDefaultSharedPreferences(androidContext()) }
+}

--- a/app/src/main/java/dev/bryanlindsey/trivia/di/ViewModelModule.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/di/ViewModelModule.kt
@@ -6,5 +6,5 @@ import org.koin.dsl.module
 
 val viewModelModule = module {
 
-    viewModel { TriviaQuestionDisplayViewModel(get()) }
+    viewModel { TriviaQuestionDisplayViewModel(get(), get()) }
 }

--- a/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/settings/SettingsFragment.kt
@@ -6,8 +6,11 @@ import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_NO
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_YES
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SeekBarPreference
 import androidx.preference.SwitchPreferenceCompat
 import dev.bryanlindsey.trivia.DEFAULT_DARK_MODE_SETTING
+
+const val NUMBER_OF_QUESTIONS_PREFERENCE_KEY = "number_of_questions"
 
 class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -30,6 +33,18 @@ class SettingsFragment : PreferenceFragmentCompat() {
             }
 
         screen.addPreference(themePreference)
+
+        val numberOfQuestionsPreference = SeekBarPreference(context).apply {
+            key = NUMBER_OF_QUESTIONS_PREFERENCE_KEY
+            title = "Questions per round"
+            min = 1
+            max = 20
+            showSeekBarValue = true
+            setDefaultValue(10)
+        }
+
+        screen.addPreference(numberOfQuestionsPreference)
+
         preferenceScreen = screen
     }
 }

--- a/app/src/main/java/dev/bryanlindsey/trivia/triviaquestiondisplay/TriviaQuestionDisplayViewModel.kt
+++ b/app/src/main/java/dev/bryanlindsey/trivia/triviaquestiondisplay/TriviaQuestionDisplayViewModel.kt
@@ -1,16 +1,20 @@
 package dev.bryanlindsey.trivia.triviaquestiondisplay
 
+import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.bryanlindsey.trivia.remote.response.TriviaApiResponse
 import dev.bryanlindsey.trivia.remote.service.TriviaService
+import dev.bryanlindsey.trivia.settings.NUMBER_OF_QUESTIONS_PREFERENCE_KEY
 import kotlinx.coroutines.launch
 
 private const val DEFAULT_QUESTION_COUNT = 10
 
-class TriviaQuestionDisplayViewModel(private val triviaService: TriviaService) : ViewModel() {
+class TriviaQuestionDisplayViewModel(
+    private val triviaService: TriviaService,
+    private val preferences: SharedPreferences) : ViewModel() {
 
     private val _triviaQuestionsLiveData = MutableLiveData<TriviaApiResponse>()
 
@@ -22,7 +26,9 @@ class TriviaQuestionDisplayViewModel(private val triviaService: TriviaService) :
 
     fun getMoreTriviaQuestions() =
         viewModelScope.launch {
-            val response = triviaService.getTriviaQuestions(DEFAULT_QUESTION_COUNT)
+            val numberOfQuestions = preferences.getInt(NUMBER_OF_QUESTIONS_PREFERENCE_KEY, DEFAULT_QUESTION_COUNT)
+
+            val response = triviaService.getTriviaQuestions(numberOfQuestions)
 
             _triviaQuestionsLiveData.value = response
         }


### PR DESCRIPTION
Let the user adjust the number of settings per round.

Really, it's more of a handy development tool so that I don't have to always scroll to the bottom to submit answers (if I set it to just 1 question, the submit button is already on-screen), and also gave me the chance to try out other preference screen stuff.